### PR TITLE
gitapp: mocking rest-client responses

### DIFF
--- a/gitapp/api/clients/restclient/restclient.go
+++ b/gitapp/api/clients/restclient/restclient.go
@@ -3,10 +3,51 @@ package restclient
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
-func Post(url string, body interface, headers http.Header) (*http.Response, error) {
+var(
+	enableMocks = false
+	mocks = make(map[string]*Mock)
+)
+
+type Mock struct {
+	Url string
+	HttpMethod string
+	Response *http.Response
+	Err error
+}
+
+func getMockId(httpMethod string, url string) string {
+	return fmt.Sprintf("%s_%s", httpMethod, url)
+}
+
+func StartMockups(){
+	enableMocks = true
+}
+
+func FlushMockups(){
+	mocks = make(map[string]*Mock)
+}
+
+func StopMockups(){
+	enableMocks = false
+}
+
+func AddMockup(mock Mock){
+	mocks[getMockId(mock.HttpMethod, mock.Url)]  = &mock
+}
+
+func Post(url string, body interface{}, headers http.Header) (*http.Response, error) {
+	if enableMocks {
+		mock := mocks[getMockId(http.MethodPost, url)]
+		if mock == nil{
+			return nil, fmt.Errorf("no mockup found for given request")
+		}
+		return mock.Response, mock.Err
+	}
+
 	jsonBytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, err

--- a/gitapp/api/domain/github/github_error.go
+++ b/gitapp/api/domain/github/github_error.go
@@ -4,6 +4,7 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 	DocumentationUrl string `json:"documentation_url"`
 	Errors []Error `json:"errors"`
+	StatusCode int `json:"status_code"`
 }
 
 type Error struct {

--- a/gitapp/api/providers/github/github_provider.go
+++ b/gitapp/api/providers/github/github_provider.go
@@ -26,7 +26,7 @@ func CreateRepo(
 
 	response, err := restclient.Post(urlCreateRepo, request, headers)
 	if err != nil {
-		log.Println("Error when trying to create new repo in github: %s", err.Error())
+		log.Printf("Error when trying to create new repo in github: %v", err.Error())
 		return nil, &github.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message: err.Error(),
@@ -50,8 +50,17 @@ func CreateRepo(
 				Message: "Invalid json response body",
 			}
 		}
-		errResponse.StatuCode = response.StatusCode
+		errResponse.StatusCode = response.StatusCode
 		return nil, &errResponse
 	}
-	return &github.CreateRepoResponse{}, nil
+
+	var result github.CreateRepoResponse
+	if err := json.Unmarshal(bytes, &result); err != nil {
+		log.Printf("Error when trying to unmarshal create repo response: %s", err.Error())
+		return nil, &github.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message: "error when trying to unmarshal github create repo response",
+		}
+	}
+	return &result, nil
 }

--- a/gitapp/api/providers/github/github_provider_test.go
+++ b/gitapp/api/providers/github/github_provider_test.go
@@ -1,11 +1,146 @@
 package github_provider
 
 import (
+	"fmt"
+	"github.com/marcosgeo/go-basics/gitapp/api/clients/restclient"
+	"github.com/marcosgeo/go-basics/gitapp/api/domain/github"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
 )
+
+func TestMain(m *testing.M){
+	restclient.StartMockups()
+	os.Exit(m.Run())
+}
+
+func TestConstants(t *testing.T){
+	assert.EqualValues(t, "Authorization", headerAuthorization)
+	assert.EqualValues(t, "token %s", headerAuthorizationFormat)
+	assert.EqualValues(t, "https://api.github.com/user/repos", urlCreateRepo)
+}
 
 func TestGetAuthorizationHeader(t *testing.T){
 	header := getAuthorizationHeader("abc123")
 	assert.EqualValues(t, "token abc123", header)
+}
+
+func TestCreateRepoErrorRestClient(t *testing.T){
+	restclient.FlushMockups()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Err: fmt.Errorf("invalid restclient response"),
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t, "invalid restclient response", err.Message)
+}
+
+func TestCreateRepoInvalidResponseBody(t *testing.T) {
+	restclient.FlushMockups()
+
+	invalidCloser, _ := os.Open("-asf3")
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: invalidCloser,
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t,"Invalid response body", err.Message)
+}
+
+func TestCreateRepoInvalidErrorInterface(t *testing.T) {
+	restclient.FlushMockups()
+
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body: ioutil.NopCloser(strings.NewReader(`{"message": 1}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t, "Invalid json response body", err.Message)
+}
+
+func TestCreateRepoUnauthorized(t *testing.T) {
+	restclient.FlushMockups()
+
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body: ioutil.NopCloser(strings.NewReader(`{"message": "Requires authentication"}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusUnauthorized, err.StatusCode)
+	assert.EqualValues(t, "Requires authentication", err.Message)
+}
+
+func TestCreateRepoInvalidSuccessResponse(t *testing.T){
+	restclient.FlushMockups()
+
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{"id": "123"}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t, "error when trying to unmarshal github create repo response", err.Message)
+}
+
+func TestCreateRepoNoError(t *testing.T){
+	restclient.FlushMockups()
+
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{"id": 123, "name": "go lang tutorial", "full_name": "full name go lang tutorial"}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.EqualValues(t, 123, response.Id)
+	assert.EqualValues(t, "go lang tutorial", response.Name)
+	assert.EqualValues(t, "full name go lang tutorial", response.FullName)
 }


### PR DESCRIPTION
mocking the rest-client responses

this strategy is important because it permits testing the other layers, eg providers, without mocking them.